### PR TITLE
API: Upgrade to phpstan 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ env:
     - SS_BASE_URL="https://localhost/"
     - DB=MYSQL
   matrix:
-    - RECIPE_VERSION=4.3.x-dev
-    - RECIPE_VERSION=4.4.x-dev
+    - RECIPE_VERSION=4.3.*
+    - RECIPE_VERSION=4.x-dev
 
 
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@ composer require --dev symbiote/silverstripe-phpstan:1.0.0 phpstan/phpstan-shim:
 
 SilverStripe 4.X
 ```
-composer require --dev symbiote/silverstripe-phpstan:2.0.0 phpstan/phpstan-shim:~0.11.0
+composer require --dev symbiote/silverstripe-phpstan
 ```
 
-NOTE: We recommend installing the phpstan-shim as currently in SilverStripe 3.X, the QueuedJobs module's dependence on superclosure forces the PHP-Parser dependency of PHPStan to be at a very outdated version.
+NOTE: Versions of PHPStan less than 0.12, we recommend installing the phpstan-shim as currently in SilverStripe 3.X,
+the QueuedJobs module's dependence on superclosure forces the PHP-Parser dependency of PHPStan to be at a very outdated
+version. From 0.12, the 'shim' install is the dfeault.
 
 ## Requirements
 

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.0",
-        "phpstan/phpstan": "~0.11.0",
-        "phpstan/phpstan-phpunit": "~0.11.0",
+        "phpstan/phpstan": "~0.12.0",
+        "phpstan/phpstan-phpunit": "~0.12.0",
         "phpunit/phpunit": "^7.5.14 || ^8.0"
     },
     "scripts": {

--- a/src/Reflection/CachedMethod.php
+++ b/src/Reflection/CachedMethod.php
@@ -8,6 +8,7 @@ use PHPStan\Reflection\ClassMemberReflection;
 use PHPStan\Type\Type;
 use PHPStan\Type\MixedType;
 use PHPStan\Reflection\Php\PhpMethodReflection;
+use PHPStan\TrinaryLogic;
 
 class CachedMethod implements MethodReflection
 {
@@ -90,5 +91,40 @@ class CachedMethod implements MethodReflection
     public function getVariants(): array
     {
             return $this->methodReflection->getVariants();
+    }
+
+    public function isDeprecated(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function isFinal(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function getDeprecatedDescription(): ?string
+    {
+        return null;
+    }
+
+    public function hasSideEffects(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function getThrowType(): ?Type
+    {
+        return null;
+    }
+
+    public function isInternal(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function getDocComment(): ?string
+    {
+        return null;
     }
 }

--- a/src/Reflection/ComponentDBFieldProperty.php
+++ b/src/Reflection/ComponentDBFieldProperty.php
@@ -7,6 +7,7 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\PropertyReflection;
 use PHPStan\Type\Type;
 use PHPStan\Type\ObjectType;
+use PHPStan\TrinaryLogic;
 
 class ComponentDBFieldProperty implements PropertyReflection
 {
@@ -42,7 +43,12 @@ class ComponentDBFieldProperty implements PropertyReflection
         $this->returnType = Utility::get_primitive_from_dbfield($className);
     }
 
-    public function getType(): Type
+    public function getReadableType(): Type
+    {
+        return $this->returnType;
+    }
+
+    public function getWritableType(): Type
     {
         return $this->returnType;
     }
@@ -73,6 +79,31 @@ class ComponentDBFieldProperty implements PropertyReflection
     }
 
     public function isWritable(): bool
+    {
+        return true;
+    }
+
+    public function isDeprecated(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function isInternal(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function getDeprecatedDescription(): ?string
+    {
+        return null;
+    }
+
+    public function getDocComment(): ?string
+    {
+        return null;
+    }
+
+    public function canChangeTypeAfterAssignment(): bool
     {
         return true;
     }

--- a/src/Reflection/ComponentHasManyMethod.php
+++ b/src/Reflection/ComponentHasManyMethod.php
@@ -8,8 +8,10 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ClassMemberReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\FunctionVariant;
+use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Type;
 use PHPStan\Type\ObjectType;
+use PHPStan\TrinaryLogic;
 
 class ComponentHasManyMethod implements MethodReflection
 {
@@ -91,6 +93,8 @@ class ComponentHasManyMethod implements MethodReflection
         if ($this->variants === null) {
             $this->variants = [
                 new FunctionVariant(
+                    new TemplateTypeMap([]),
+                    null,
                     $this->getParameters(),
                     $this->isVariadic(),
                     $this->getReturnType()
@@ -98,5 +102,40 @@ class ComponentHasManyMethod implements MethodReflection
             ];
         }
         return $this->variants;
+    }
+
+    public function isDeprecated(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function isFinal(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function getDeprecatedDescription(): ?string
+    {
+        return null;
+    }
+
+    public function hasSideEffects(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function getThrowType(): ?Type
+    {
+        return null;
+    }
+
+    public function isInternal(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function getDocComment(): ?string
+    {
+        return null;
     }
 }

--- a/src/Reflection/ComponentHasOneMethod.php
+++ b/src/Reflection/ComponentHasOneMethod.php
@@ -6,8 +6,10 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ClassMemberReflection;
 use PHPStan\Reflection\FunctionVariant;
+use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Type;
 use PHPStan\Type\ObjectType;
+use PHPStan\TrinaryLogic;
 
 class ComponentHasOneMethod implements MethodReflection
 {
@@ -89,6 +91,8 @@ class ComponentHasOneMethod implements MethodReflection
         if ($this->variants === null) {
             $this->variants = [
                 new FunctionVariant(
+                    new TemplateTypeMap([]),
+                    null,
                     $this->getParameters(),
                     $this->isVariadic(),
                     $this->getReturnType()
@@ -96,5 +100,40 @@ class ComponentHasOneMethod implements MethodReflection
             ];
         }
         return $this->variants;
+    }
+
+    public function isDeprecated(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function isFinal(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function getDeprecatedDescription(): ?string
+    {
+        return null;
+    }
+
+    public function hasSideEffects(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function getThrowType(): ?Type
+    {
+        return null;
+    }
+
+    public function isInternal(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function getDocComment(): ?string
+    {
+        return null;
     }
 }

--- a/src/Reflection/ComponentHasOneProperty.php
+++ b/src/Reflection/ComponentHasOneProperty.php
@@ -6,6 +6,7 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\PropertyReflection;
 use PHPStan\Type\Type;
 use PHPStan\Type\IntegerType;
+use PHPStan\TrinaryLogic;
 
 class ComponentHasOneProperty implements PropertyReflection
 {
@@ -38,7 +39,12 @@ class ComponentHasOneProperty implements PropertyReflection
         $this->returnType = new IntegerType;
     }
 
-    public function getType(): Type
+    public function getReadableType(): Type
+    {
+        return $this->returnType;
+    }
+
+    public function getWritableType(): Type
     {
         return $this->returnType;
     }
@@ -69,6 +75,31 @@ class ComponentHasOneProperty implements PropertyReflection
     }
 
     public function isWritable(): bool
+    {
+        return true;
+    }
+
+    public function isDeprecated(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function isInternal(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function getDeprecatedDescription(): ?string
+    {
+        return null;
+    }
+
+    public function getDocComment(): ?string
+    {
+        return null;
+    }
+
+    public function canChangeTypeAfterAssignment(): bool
     {
         return true;
     }

--- a/src/Reflection/ComponentManyManyMethod.php
+++ b/src/Reflection/ComponentManyManyMethod.php
@@ -8,8 +8,10 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\FunctionVariant;
 use PHPStan\Reflection\ClassMemberReflection;
+use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Type;
 use PHPStan\Type\ObjectType;
+use PHPStan\TrinaryLogic;
 
 class ComponentManyManyMethod implements MethodReflection
 {
@@ -97,6 +99,8 @@ class ComponentManyManyMethod implements MethodReflection
         if ($this->variants === null) {
             $this->variants = [
                 new FunctionVariant(
+                    new TemplateTypeMap([]),
+                    null,
                     $this->getParameters(),
                     $this->isVariadic(),
                     $this->getReturnType()
@@ -104,5 +108,40 @@ class ComponentManyManyMethod implements MethodReflection
             ];
         }
         return $this->variants;
+    }
+
+    public function isDeprecated(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function isFinal(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function getDeprecatedDescription(): ?string
+    {
+        return null;
+    }
+
+    public function hasSideEffects(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function getThrowType(): ?Type
+    {
+        return null;
+    }
+
+    public function isInternal(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function getDocComment(): ?string
+    {
+        return null;
     }
 }

--- a/src/Reflection/ViewableDataGetNullProperty.php
+++ b/src/Reflection/ViewableDataGetNullProperty.php
@@ -8,6 +8,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\StringType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\NullType;
+use PHPStan\TrinaryLogic;
 
 class ViewableDataGetNullProperty implements PropertyReflection
 {
@@ -40,7 +41,12 @@ class ViewableDataGetNullProperty implements PropertyReflection
         $this->returnType = new NullType;
     }
 
-    public function getType(): Type
+    public function getReadableType(): Type
+    {
+        return $this->returnType;
+    }
+
+    public function getWritableType(): Type
     {
         return $this->returnType;
     }
@@ -71,6 +77,31 @@ class ViewableDataGetNullProperty implements PropertyReflection
     }
 
     public function isWritable(): bool
+    {
+        return true;
+    }
+
+    public function isDeprecated(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function isInternal(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function getDeprecatedDescription(): ?string
+    {
+        return null;
+    }
+
+    public function getDocComment(): ?string
+    {
+        return null;
+    }
+
+    public function canChangeTypeAfterAssignment(): bool
     {
         return true;
     }

--- a/src/Reflection/ViewableDataGetProperty.php
+++ b/src/Reflection/ViewableDataGetProperty.php
@@ -8,6 +8,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\StringType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
+use PHPStan\TrinaryLogic;
 
 class ViewableDataGetProperty implements PropertyReflection
 {
@@ -40,7 +41,12 @@ class ViewableDataGetProperty implements PropertyReflection
         $this->returnType = new MixedType;
     }
 
-    public function getType(): Type
+    public function getReadableType(): Type
+    {
+        return $this->returnType;
+    }
+
+    public function getWritableType(): Type
     {
         return $this->returnType;
     }
@@ -71,6 +77,31 @@ class ViewableDataGetProperty implements PropertyReflection
     }
 
     public function isWritable(): bool
+    {
+        return true;
+    }
+
+    public function isDeprecated(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function isInternal(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function getDeprecatedDescription(): ?string
+    {
+        return null;
+    }
+
+    public function getDocComment(): ?string
+    {
+        return null;
+    }
+
+    public function canChangeTypeAfterAssignment(): bool
     {
         return true;
     }

--- a/src/Type/DBFieldStaticReturnTypeExtension.php
+++ b/src/Type/DBFieldStaticReturnTypeExtension.php
@@ -40,7 +40,6 @@ class DBFieldStaticReturnTypeExtension implements \PHPStan\Type\DynamicStaticMet
                 $arg = $methodCall->args[0]->value;
                 $type = Utility::getTypeFromVariable($arg, $methodReflection);
                 return $type;
-            break;
         }
         $arg = $methodCall->args[0]->value;
 

--- a/src/Type/DataListReturnTypeExtension.php
+++ b/src/Type/DataListReturnTypeExtension.php
@@ -53,7 +53,6 @@ class DataListReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTy
             case 'first':
             case 'last':
                 return true;
-            break;
 
             /*case 'min':
             case 'max':
@@ -103,11 +102,9 @@ class DataListReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTy
             case 'removeByFilter':
             case 'removeAll':
                 return $type;
-            break;
 
             case 'getIDList':
                 return new ArrayType(new IntegerType, new IntegerType);
-            break;
 
             // DataObject[]
             case 'toArray':
@@ -119,7 +116,6 @@ class DataListReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTy
                     return new ArrayType(new IntegerType, $type->getItemType());
                 }
                 return Utility::getMethodReturnType($methodReflection);
-            break;
 
             // DataObject
             case 'find':
@@ -127,12 +123,9 @@ class DataListReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTy
             case 'first':
             case 'last':
                 return $type->getIterableValueType();
-            break;
 
             default:
                 throw new Exception('Unhandled method call: '.$name);
-            break;
         }
-        return Utility::getMethodReturnType($methodReflection);
     }
 }

--- a/src/Type/DataListType.php
+++ b/src/Type/DataListType.php
@@ -8,11 +8,10 @@ use PHPStan\Reflection\PropertyReflection;
 use PHPStan\Type\Type;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\IterableTypeTrait;
-use PHPStan\Type\StaticResolvableType;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\VerbosityLevel;
 
-class DataListType extends ObjectType implements StaticResolvableType
+class DataListType extends ObjectType
 {
     /** @var Type */
     private $itemType;
@@ -38,16 +37,6 @@ class DataListType extends ObjectType implements StaticResolvableType
     public function getIterableValueType(): Type
     {
         return $this->itemType;
-    }
-
-    public function resolveStatic(string $className): Type
-    {
-        return $this;
-    }
-
-    public function changeBaseClass(string $className): StaticResolvableType
-    {
-        return $this;
     }
 
     public function isDocumentableNatively(): bool

--- a/src/Type/DataObjectGetStaticReturnTypeExtension.php
+++ b/src/Type/DataObjectGetStaticReturnTypeExtension.php
@@ -50,7 +50,6 @@ class DataObjectGetStaticReturnTypeExtension implements \PHPStan\Type\DynamicSta
                     $callerClass = $scope->getClassReflection()->getName();
                 }
                 return new DataListType(ClassHelper::DataList, new ObjectType($callerClass));
-            break;
 
             case 'get_one':
             case 'get_by_id':
@@ -69,7 +68,6 @@ class DataObjectGetStaticReturnTypeExtension implements \PHPStan\Type\DynamicSta
                     $callerClass = $scope->getClassReflection()->getName();
                 }
                 return new ObjectType($callerClass);
-            break;
         }
         // NOTE(mleutenegger): 2019-11-10
         // taken from https://github.com/phpstan/phpstan#dynamic-return-type-extensions

--- a/src/Type/DataObjectReturnTypeExtension.php
+++ b/src/Type/DataObjectReturnTypeExtension.php
@@ -35,15 +35,12 @@ class DataObjectReturnTypeExtension implements DynamicMethodReturnTypeExtension
         switch ($name) {
             case 'getCMSFields':
                 return true;
-            break;
 
             case 'dbObject':
                 return true;
-            break;
 
             case 'newClassInstance':
                 return true;
-            break;
         }
         return false;
     }
@@ -74,7 +71,6 @@ class DataObjectReturnTypeExtension implements DynamicMethodReturnTypeExtension
                 }
                 $className = $objectType->getClassName();
                 return new FieldListType($className);
-            break;
 
             case 'dbObject':
                 $className = '';
@@ -120,7 +116,6 @@ class DataObjectReturnTypeExtension implements DynamicMethodReturnTypeExtension
                 //     return Utility::getMethodReturnType($methodReflection);
                 // }
                 return $dbFieldType;
-            break;
 
             case 'newClassInstance':
                 if (count($methodCall->args) === 0) {
@@ -129,12 +124,9 @@ class DataObjectReturnTypeExtension implements DynamicMethodReturnTypeExtension
                 $arg = $methodCall->args[0]->value;
                 $type = Utility::getTypeFromVariable($arg, $methodReflection);
                 return $type;
-            break;
 
             default:
                 throw new Exception('Unhandled method call: '.$name);
-            break;
         }
-        return Utility::getMethodReturnType($methodReflection);
     }
 }

--- a/src/Type/ExtensionReturnTypeExtension.php
+++ b/src/Type/ExtensionReturnTypeExtension.php
@@ -32,7 +32,6 @@ class ExtensionReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnT
         switch ($name) {
             case 'getOwner':
                 return true;
-            break;
         }
         return false;
     }
@@ -98,13 +97,10 @@ class ExtensionReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnT
                     return $types[0];
                 }
                 return new UnionType($types);
-            break;
 
             default:
                 throw new Exception('Unhandled method call: '.$name);
-            break;
         }
-        return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
     }
 
     private function getOwnerClassNamesByExtensionClassName()
@@ -136,14 +132,12 @@ class ExtensionReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnT
         foreach ($classes as $class) {
             $hasTrait = false;
             foreach ($classes as $subclass) {
-                if ($subclass === $class || is_subclass_of($subclass, $class)) {
-                    $hasTrait = false;
-                    foreach (class_uses($class) as $trait) {
-                        $hasTrait = $hasTrait || $trait == ClassHelper::Extensible;
-                    }
-                    if ($hasTrait) {
-                        $result[$subclass] = $subclass;
-                    }
+                $hasTrait = false;
+                foreach (class_uses($class) as $trait) {
+                    $hasTrait = $hasTrait || $trait == ClassHelper::Extensible;
+                }
+                if ($hasTrait) {
+                    $result[$subclass] = $subclass;
                 }
             }
         }

--- a/src/Type/FieldListType.php
+++ b/src/Type/FieldListType.php
@@ -9,11 +9,11 @@ use PHPStan\Reflection\PropertyReflection;
 use PHPStan\Type\Type;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\IterableTypeTrait;
-use PHPStan\Type\StaticResolvableType;
+use PHPStan\Type\StaticType;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\VerbosityLevel;
 
-class FieldListType extends ObjectType implements StaticResolvableType
+class FieldListType extends ObjectType
 {
 
     /**
@@ -42,16 +42,6 @@ class FieldListType extends ObjectType implements StaticResolvableType
     public function getIterableValueType(): Type
     {
         return $this->itemType;
-    }
-
-    public function resolveStatic(string $className): Type
-    {
-        return $this;
-    }
-
-    public function changeBaseClass(string $className): StaticResolvableType
-    {
-        return $this;
     }
 
     public function isDocumentableNatively(): bool

--- a/src/Type/InjectorReturnTypeExtension.php
+++ b/src/Type/InjectorReturnTypeExtension.php
@@ -42,13 +42,9 @@ class InjectorReturnTypeExtension implements DynamicMethodReturnTypeExtension
                     Utility::getMethodReturnType($methodReflection)
                 );
                 return $type;
-            break;
 
             default:
                 throw new LogicException('Unhandled method call: '.$name);
-            break;
         }
-
-        return Utility::getMethodReturnType($methodReflection);
     }
 }

--- a/src/Type/SingletonReturnTypeExtension.php
+++ b/src/Type/SingletonReturnTypeExtension.php
@@ -34,7 +34,6 @@ class SingletonReturnTypeExtension implements DynamicFunctionReturnTypeExtension
                 $arg = $functionCall->args[0]->value;
                 $type = Utility::getTypeFromInjectorVariable($arg, Utility::getMethodReturnType($functionReflection));
                 return $type;
-            break;
         }
         return Utility::getMethodReturnType($functionReflection);
     }

--- a/tests/Reflection/SiteTreePropertyClassReflectionExtensionTest.php
+++ b/tests/Reflection/SiteTreePropertyClassReflectionExtensionTest.php
@@ -58,13 +58,13 @@ final class SiteTreePropertyClassReflectionExtensionTest extends \PHPStan\Testin
     {
         $classReflection = $this->broker->getClass(ClassHelper::SiteTree);
         $propertyReflection = $this->property->getProperty($classReflection, 'ParentID');
-        self::assertSame(IntegerType::class, get_class($propertyReflection->getType()));
+        self::assertSame(IntegerType::class, get_class($propertyReflection->getReadableType()));
     }
 
     public function testUnusedVariableProperty(): void
     {
         $classReflection = $this->broker->getClass(ClassHelper::SiteTree);
         $propertyReflection = $this->property->getProperty($classReflection, 'UnusedVariable');
-        self::assertSame(NullType::class, get_class($propertyReflection->getType()));
+        self::assertSame(NullType::class, get_class($propertyReflection->getReadableType()));
     }
 }

--- a/tests/ResolverTest.php
+++ b/tests/ResolverTest.php
@@ -118,22 +118,22 @@ abstract class ResolverTest extends \PHPStan\Testing\TestCase
 
         $phpDocInheritanceResolver = new PhpDocInheritanceResolver($fileTypeMapper);
 
-		$resolver = new NodeScopeResolver(
-			$broker,
-			self::getReflectors()[0],
-			$this->getClassReflectionExtensionRegistryProvider(),
-			$this->getParser(),
-			$fileTypeMapper,
-			self::getContainer()->getByType(PhpVersion::class),
-			$phpDocInheritanceResolver,
-			$fileHelper,
-			$typeSpecifier,
-			true,
-			true,
-			true,
-			[],
-			['baz']
-		);
+        $resolver = new NodeScopeResolver(
+            $broker,
+            self::getReflectors()[0],
+            $this->getClassReflectionExtensionRegistryProvider(),
+            $this->getParser(),
+            $fileTypeMapper,
+            self::getContainer()->getByType(PhpVersion::class),
+            $phpDocInheritanceResolver,
+            $fileHelper,
+            $typeSpecifier,
+            true,
+            true,
+            true,
+            [],
+            ['baz']
+        );
 
         $broker = $this->createBroker(
             $dynamicMethodReturnTypeExtensions,

--- a/tests/ResolverTest.php
+++ b/tests/ResolverTest.php
@@ -10,15 +10,20 @@ use PHPStan\Analyser\ScopeContext;
 use PHPStan\Cache\Cache;
 use PHPStan\File\FileHelper;
 use PHPStan\PhpDoc\PhpDocStringResolver;
+use PHPStan\PhpDoc\PhpDocInheritanceResolver;
+use PHPStan\PhpDoc\PhpDocNodeResolver;
 use PHPStan\Type\FileTypeMapper;
 use PHPStan\Type\VerbosityLevel;
 use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Reflection\BrokerAwareExtension;
+use PHPStan\Reflection\ReflectionProvider\DirectReflectionProviderProvider;
 use PHPStan\File\FuzzyRelativePathHelper;
+use PHPStan\File\NullRelativePathHelper;
 use PHPStan\Broker\AnonymousClassNameHelper;
 use PHPStan\Rules\Properties\PropertyReflectionFinder;
 use PHPStan\Node\VirtualNode;
+use PHPStan\Php\PhpVersion;
 
 abstract class ResolverTest extends \PHPStan\Testing\TestCase
 {
@@ -31,7 +36,6 @@ abstract class ResolverTest extends \PHPStan\Testing\TestCase
         string $expression,
         array $dynamicMethodReturnTypeExtensions = [],
         array $dynamicStaticMethodReturnTypeExtensions = [],
-        array $dynamicFunctionReturnTypeExtensions = [],
         string $evaluatedPointExpression = 'die;'
     ) {
 
@@ -49,31 +53,35 @@ abstract class ResolverTest extends \PHPStan\Testing\TestCase
         // Taken from:
         // - phpstan\tests\PHPStan\Analyser\NodeScopeResolverTest.php
         //
-        $this->processFile($file, function (\PhpParser\Node $node, Scope $scope) use ($description, $expression, $evaluatedPointExpression) {
-            if ($node instanceof VirtualNode) {
-                return;
-            }
-            $printer = new \PhpParser\PrettyPrinter\Standard();
-            $printedNode = $printer->prettyPrint([$node]);
-            if ($printedNode === $evaluatedPointExpression) {
-                /** @var \PhpParser\Node\Stmt\Expression $expressionNode */
-                $expressionNode = $this->getParser()->parseString(sprintf('<?php %s;', $expression))[0];
-                $type = $scope->getType($expressionNode->expr);
-                $this->assertTypeDescribe(
-                    $description,
-                    $type->describe(VerbosityLevel::precise()),
-                    sprintf('%s at %s', $expression, $evaluatedPointExpression)
-                );
-            }
-        }, $dynamicMethodReturnTypeExtensions, $dynamicStaticMethodReturnTypeExtensions, $dynamicFunctionReturnTypeExtensions);
+        $this->processFile(
+            $file,
+            function (\PhpParser\Node $node, Scope $scope) use ($description, $expression, $evaluatedPointExpression) {
+                if ($node instanceof VirtualNode) {
+                    return;
+                }
+                $printer = new \PhpParser\PrettyPrinter\Standard();
+                $printedNode = $printer->prettyPrint([$node]);
+                if ($printedNode === $evaluatedPointExpression) {
+                    /** @var \PhpParser\Node\Stmt\Expression $expressionNode */
+                    $expressionNode = $this->getParser()->parseString(sprintf('<?php %s;', $expression))[0];
+                    $type = $scope->getType($expressionNode->expr);
+                    $this->assertTypeDescribe(
+                        $description,
+                        $type->describe(VerbosityLevel::precise()),
+                        sprintf('%s at %s', $expression, $evaluatedPointExpression)
+                    );
+                }
+            },
+            $dynamicMethodReturnTypeExtensions,
+            $dynamicStaticMethodReturnTypeExtensions
+        );
     }
 
     private function processFile(
         string $file,
         \Closure $callback,
         array $dynamicMethodReturnTypeExtensions = [],
-        array $dynamicStaticMethodReturnTypeExtensions = [],
-        array $dynamicFunctionReturnTypeExtensions = []
+        array $dynamicStaticMethodReturnTypeExtensions = []
     ) {
         // NOTE(Jake): 2018-04-21
         //
@@ -81,28 +89,13 @@ abstract class ResolverTest extends \PHPStan\Testing\TestCase
         // - phpstan\tests\PHPStan\Analyser\NodeScopeResolverTest.php
         //
         $phpDocStringResolver = $this->getContainer()->getByType(PhpDocStringResolver::class);
+        $phpDocNodeResolver = $this->getContainer()->getByType(PhpDocNodeResolver::class);
 
         $printer = new \PhpParser\PrettyPrinter\Standard();
         $broker = $this->createBroker();
 
-        // NOTE(Jake): 2018-04-22
-        //
-        // Hack in DynamicFunctionReturnType support
-        //
-        if ($dynamicFunctionReturnTypeExtensions) {
-            $hack = $broker->getDynamicFunctionReturnTypeExtensions();
-            $hack = array_merge($hack, $dynamicFunctionReturnTypeExtensions);
-            foreach ($dynamicFunctionReturnTypeExtensions as $extension) {
-                if ($extension instanceof BrokerAwareExtension) {
-                    $extension->setBroker($broker);
-                }
-            }
-            $refProperty = new \ReflectionProperty($broker, 'dynamicFunctionReturnTypeExtensions');
-            $refProperty->setAccessible(true);
-            $refProperty->setValue($broker, $hack);
-        }
         $workingDirectory = __DIR__;
-        $relativePathHelper = new FuzzyRelativePathHelper($workingDirectory, DIRECTORY_SEPARATOR, []);
+        $relativePathHelper = new FuzzyRelativePathHelper(new NullRelativePathHelper(), $workingDirectory, [], DIRECTORY_SEPARATOR);
         $anonymousClassNameHelper = new AnonymousClassNameHelper(new FileHelper($workingDirectory), $relativePathHelper);
 
         $typeSpecifier = $this->createTypeSpecifier(
@@ -112,50 +105,40 @@ abstract class ResolverTest extends \PHPStan\Testing\TestCase
             []
         );
 
-        $resolver = new NodeScopeResolver(
-            $broker,
+        $fileHelper = new FileHelper($workingDirectory);
+
+        $fileTypeMapper =new FileTypeMapper(
+            new DirectReflectionProviderProvider($broker),
             $this->getParser(),
-            new FileTypeMapper(
-                $this->getParser(),
-                $phpDocStringResolver,
-                $this->createMock(Cache::class),
-                $anonymousClassNameHelper,
-                new \PHPStan\PhpDoc\TypeNodeResolver([])
-            ),
-            new FileHelper($workingDirectory),
-            $typeSpecifier,
-            true,
-            true,
-            true,
-            [
-                //\EarlyTermination\Foo::class => [
-                //    'doFoo',
-                //],
-            ],
-            true
+            $phpDocStringResolver,
+            $phpDocNodeResolver,
+            $this->createMock(Cache::class),
+            $anonymousClassNameHelper
         );
+
+        $phpDocInheritanceResolver = new PhpDocInheritanceResolver($fileTypeMapper);
+
+		$resolver = new NodeScopeResolver(
+			$broker,
+			self::getReflectors()[0],
+			$this->getClassReflectionExtensionRegistryProvider(),
+			$this->getParser(),
+			$fileTypeMapper,
+			self::getContainer()->getByType(PhpVersion::class),
+			$phpDocInheritanceResolver,
+			$fileHelper,
+			$typeSpecifier,
+			true,
+			true,
+			true,
+			[],
+			['baz']
+		);
+
         $broker = $this->createBroker(
             $dynamicMethodReturnTypeExtensions,
             $dynamicStaticMethodReturnTypeExtensions
         );
-
-        // NOTE(Jake): 2018-04-22
-        //
-        // Hack in DynamicFunctionReturnType support
-        // -DUPLICATE CODE-
-        //
-        if ($dynamicFunctionReturnTypeExtensions) {
-            $hack = $broker->getDynamicFunctionReturnTypeExtensions();
-            $hack = array_merge($hack, $dynamicFunctionReturnTypeExtensions);
-            foreach ($dynamicFunctionReturnTypeExtensions as $extension) {
-                if ($extension instanceof BrokerAwareExtension) {
-                    $extension->setBroker($broker);
-                }
-            }
-            $refProperty = new \ReflectionProperty($broker, 'dynamicFunctionReturnTypeExtensions');
-            $refProperty->setAccessible(true);
-            $refProperty->setValue($broker, $hack);
-        }
 
         $scopeFactory = $this->createScopeFactory($broker, $typeSpecifier);
         $scope = $scopeFactory->create(ScopeContext::create($file));

--- a/tests/Type/InjectorReturnTypeExtensionTest.php
+++ b/tests/Type/InjectorReturnTypeExtensionTest.php
@@ -82,16 +82,19 @@ class InjectorReturnTypeExtensionTest extends ResolverTest
         string $description,
         string $expression
     ) {
-        $dynamicFunctionReturnTypeExtensions = [
-            new SingletonReturnTypeExtension(),
-        ];
         $this->assertTypes(
             __DIR__ . '/data/data-object-dynamic-method-return-types.php',
             $description,
             $expression,
-            [],
-            [],
-            $dynamicFunctionReturnTypeExtensions
         );
     }
+
+	public function getDynamicFunctionReturnTypeExtensions(): array
+	{
+        return [
+            new SingletonReturnTypeExtension(),
+        ];
+	}
+
+
 }

--- a/tests/Type/InjectorReturnTypeExtensionTest.php
+++ b/tests/Type/InjectorReturnTypeExtensionTest.php
@@ -85,16 +85,14 @@ class InjectorReturnTypeExtensionTest extends ResolverTest
         $this->assertTypes(
             __DIR__ . '/data/data-object-dynamic-method-return-types.php',
             $description,
-            $expression,
+            $expression
         );
     }
 
-	public function getDynamicFunctionReturnTypeExtensions(): array
-	{
+    public function getDynamicFunctionReturnTypeExtensions(): array
+    {
         return [
             new SingletonReturnTypeExtension(),
         ];
-	}
-
-
+    }
 }

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -5,11 +5,10 @@ parameters:
     ignoreErrors:
         # Ignore as PHPStan has no support for method_exists()
         # - '%Call to an undefined method PHPStan\\Type\\Type::getItemType()%'
-    exclude_files:
-        # Exclude bootstrap file
-        - tests/bootstrap-phpstan.php
     excludes_analyse:
         # Exclude test data files
+        - tests/bootstrap-phpstan.php
+        # Exclude bootstrap file
         - %currentWorkingDirectory%/tests/*/Data/*
     autoload_directories:
         # NOTE(Jake): 2018-05-20


### PR DESCRIPTION
Unfortunately retaining 0.11 support isn’t feasible but that seems like
an acceptable tradeoff.

Note that some of the type-hinting of DataLists will now be doable with
phpstan’s template features - we can type hint DataList<Member> for
example, and we can commit some @phpstan-return clauses to the core
framework to support this.